### PR TITLE
Fix issues around configuration changes

### DIFF
--- a/app/src/main/java/org/oppia/android/app/player/exploration/ExplorationActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/player/exploration/ExplorationActivityPresenter.kt
@@ -128,7 +128,7 @@ class ExplorationActivityPresenter @Inject constructor(
 
   fun loadExplorationFragment(readingTextSize: ReadingTextSize) {
     if (getExplorationFragment() == null) {
-      activity.supportFragmentManager.beginTransaction().replace(
+      activity.supportFragmentManager.beginTransaction().add(
         R.id.exploration_fragment_placeholder,
         ExplorationFragment.newInstance(
           profileId, topicId, storyId, explorationId, readingTextSize

--- a/app/src/main/java/org/oppia/android/app/player/state/StateFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/StateFragmentPresenter.kt
@@ -180,7 +180,7 @@ class StateFragmentPresenter @Inject constructor(
 
   fun handleAnswerReadyForSubmission(answer: UserAnswer) {
     // An interaction has indicated that an answer is ready for submission.
-    handleSubmitAnswer(answer)
+    handleSubmitAnswer(answer, canSubmitAnswer = true)
   }
 
   fun onContinueButtonClicked() {
@@ -224,9 +224,7 @@ class StateFragmentPresenter @Inject constructor(
 
   fun handleKeyboardAction() {
     hideKeyboard()
-    if (viewModel.getCanSubmitAnswer().get() == true) {
-      handleSubmitAnswer(viewModel.getPendingAnswer(recyclerViewAssembler::getPendingAnswerHandler))
-    }
+    handleSubmitAnswer(viewModel.getPendingAnswer(recyclerViewAssembler::getPendingAnswerHandler))
   }
 
   fun onHintAvailable(helpIndex: HelpIndex, isCurrentStatePendingState: Boolean) {
@@ -425,8 +423,15 @@ class StateFragmentPresenter @Inject constructor(
     }
   }
 
-  private fun handleSubmitAnswer(answer: UserAnswer) {
-    subscribeToAnswerOutcome(explorationProgressController.submitAnswer(answer).toLiveData())
+  private fun handleSubmitAnswer(
+    answer: UserAnswer,
+    canSubmitAnswer: Boolean = viewModel.getCanSubmitAnswer().get() ?: false
+  ) {
+    // This check seems to avoid a crash on configuration change when attempting to resubmit answers
+    // after encountering a submit-time error, but it's also more correct to keep it.
+    if (canSubmitAnswer) {
+      subscribeToAnswerOutcome(explorationProgressController.submitAnswer(answer).toLiveData())
+    }
   }
 
   fun dismissConceptCard() {

--- a/app/src/main/java/org/oppia/android/app/player/state/StatePlayerRecyclerViewAssembler.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/StatePlayerRecyclerViewAssembler.kt
@@ -329,7 +329,10 @@ class StatePlayerRecyclerViewAssembler private constructor(
       hasPreviousButton,
       isSplitView.get()!!,
       writtenTranslationContext
-    )
+    ).also {
+      // Ensure that potential errors are re-detected in cases of configuration changes.
+      (it as? InteractionAnswerHandler)?.checkPendingAnswerError(rawUserAnswer.lastErrorCategory)
+    }
   }
 
   private fun addContentItem(

--- a/app/src/main/java/org/oppia/android/app/player/state/StateViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/StateViewModel.kt
@@ -4,9 +4,9 @@ import androidx.databinding.ObservableField
 import androidx.databinding.ObservableList
 import androidx.lifecycle.ViewModel
 import org.oppia.android.app.fragment.FragmentScope
+import org.oppia.android.app.model.AnswerErrorCategory
 import org.oppia.android.app.model.RawUserAnswer
 import org.oppia.android.app.model.UserAnswer
-import org.oppia.android.app.player.state.answerhandling.AnswerErrorCategory
 import org.oppia.android.app.player.state.answerhandling.InteractionAnswerHandler
 import org.oppia.android.app.player.state.itemviewmodel.StateItemViewModel
 import org.oppia.android.app.viewmodel.ObservableArrayList

--- a/app/src/main/java/org/oppia/android/app/player/state/answerhandling/InteractionAnswerHandler.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/answerhandling/InteractionAnswerHandler.kt
@@ -1,5 +1,6 @@
 package org.oppia.android.app.player.state.answerhandling
 
+import org.oppia.android.app.model.AnswerErrorCategory
 import org.oppia.android.app.model.RawUserAnswer
 import org.oppia.android.app.model.UserAnswer
 
@@ -43,12 +44,4 @@ interface InteractionAnswerHandler {
  */
 interface InteractionAnswerReceiver {
   fun onAnswerReadyForSubmission(answer: UserAnswer)
-}
-
-/** Categories of errors that can be inferred from a pending answer.  */
-enum class AnswerErrorCategory {
-  /** Corresponds to errors that may be found while the user is trying to input an answer.  */
-  REAL_TIME,
-  /** Corresponds to errors that may be found only when a user tries to submit an answer.  */
-  SUBMIT_TIME
 }

--- a/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/DragAndDropSortInteractionViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/DragAndDropSortInteractionViewModel.kt
@@ -3,6 +3,7 @@ package org.oppia.android.app.player.state.itemviewmodel
 import androidx.databinding.Observable
 import androidx.databinding.ObservableField
 import androidx.recyclerview.widget.RecyclerView
+import org.oppia.android.app.model.AnswerErrorCategory
 import org.oppia.android.app.model.Interaction
 import org.oppia.android.app.model.InteractionObject
 import org.oppia.android.app.model.ListOfSetsOfHtmlStrings
@@ -143,6 +144,7 @@ class DragAndDropSortInteractionViewModel private constructor(
       ListOfSetsOfTranslatableHtmlContentIds.newBuilder().apply {
         addAllContentIdLists(htmlContentIds)
       }.build()
+    lastErrorCategory = AnswerErrorCategory.NO_ERROR
   }.build()
 
   /** Returns an HTML list containing all of the HTML string elements as items in the list. */

--- a/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/ImageRegionSelectionInteractionViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/ImageRegionSelectionInteractionViewModel.kt
@@ -3,6 +3,7 @@ package org.oppia.android.app.player.state.itemviewmodel
 import androidx.databinding.Observable
 import androidx.databinding.ObservableField
 import org.oppia.android.R
+import org.oppia.android.app.model.AnswerErrorCategory
 import org.oppia.android.app.model.ClickOnImage
 import org.oppia.android.app.model.ImageWithRegions.LabeledRegion
 import org.oppia.android.app.model.Interaction
@@ -89,6 +90,7 @@ class ImageRegionSelectionInteractionViewModel private constructor(
     if (answerText.isNotEmpty()) {
       imageRegionSelection = selectableRegions.find { it.label == answerText.toString() }
     }
+    lastErrorCategory = AnswerErrorCategory.NO_ERROR
   }.build()
 
   private fun parseClickOnImage(answerTextString: String): ClickOnImage {

--- a/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/RatioExpressionInputInteractionViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/RatioExpressionInputInteractionViewModel.kt
@@ -5,13 +5,13 @@ import android.text.TextWatcher
 import androidx.databinding.Observable
 import androidx.databinding.ObservableField
 import org.oppia.android.R
+import org.oppia.android.app.model.AnswerErrorCategory
 import org.oppia.android.app.model.Interaction
 import org.oppia.android.app.model.InteractionObject
 import org.oppia.android.app.model.RawUserAnswer
 import org.oppia.android.app.model.UserAnswer
 import org.oppia.android.app.model.WrittenTranslationContext
 import org.oppia.android.app.parser.StringToRatioParser
-import org.oppia.android.app.player.state.answerhandling.AnswerErrorCategory
 import org.oppia.android.app.player.state.answerhandling.InteractionAnswerErrorOrAvailabilityCheckReceiver
 import org.oppia.android.app.player.state.answerhandling.InteractionAnswerHandler
 import org.oppia.android.app.player.state.answerhandling.InteractionAnswerReceiver
@@ -33,9 +33,10 @@ class RatioExpressionInputInteractionViewModel private constructor(
   private val translationController: TranslationController
 ) : StateItemViewModel(ViewType.RATIO_EXPRESSION_INPUT_INTERACTION), InteractionAnswerHandler {
   private var pendingAnswerError: String? = null
-  var answerText: CharSequence = rawUserAnswer.textualAnswer ?: ""
+  var answerText: CharSequence = rawUserAnswer.textualAnswer
   var isAnswerAvailable = ObservableField<Boolean>(false)
   var errorMessage = ObservableField<String>("")
+  private var currentErrorCategory = AnswerErrorCategory.NO_ERROR
 
   val hintText: CharSequence = deriveHintText(interaction)
   private val stringToRatioParser: StringToRatioParser = StringToRatioParser()
@@ -55,7 +56,6 @@ class RatioExpressionInputInteractionViewModel private constructor(
 
     errorMessage.addOnPropertyChangedCallback(callback)
     isAnswerAvailable.addOnPropertyChangedCallback(callback)
-    checkPendingAnswerError(AnswerErrorCategory.REAL_TIME)
   }
 
   override fun getPendingAnswer(): UserAnswer = UserAnswer.newBuilder().apply {
@@ -75,23 +75,29 @@ class RatioExpressionInputInteractionViewModel private constructor(
     if (answerText.isNotEmpty()) {
       textualAnswer = answerText.toString()
     }
+    lastErrorCategory = currentErrorCategory
   }.build()
 
   /** It checks the pending error for the current ratio input, and correspondingly updates the error string based on the specified error category. */
   override fun checkPendingAnswerError(category: AnswerErrorCategory): String? {
     if (answerText.isNotEmpty()) {
-      when (category) {
-        AnswerErrorCategory.REAL_TIME ->
-          pendingAnswerError =
-            stringToRatioParser.getRealTimeAnswerError(answerText.toString())
-              .getErrorMessageFromStringRes(resourceHandler)
-        AnswerErrorCategory.SUBMIT_TIME ->
-          pendingAnswerError =
-            stringToRatioParser.getSubmitTimeError(
-              answerText.toString(),
-              numberOfTerms = numberOfTerms
-            ).getErrorMessageFromStringRes(resourceHandler)
+      pendingAnswerError = when (category) {
+        AnswerErrorCategory.REAL_TIME -> {
+          stringToRatioParser.getRealTimeAnswerError(answerText.toString())
+            .getErrorMessageFromStringRes(resourceHandler)
+        }
+        AnswerErrorCategory.SUBMIT_TIME -> {
+          stringToRatioParser.getSubmitTimeError(
+            answerText.toString(),
+            numberOfTerms = numberOfTerms
+          ).getErrorMessageFromStringRes(resourceHandler)
+        }
+        AnswerErrorCategory.ANSWER_ERROR_CATEGORY_UNSPECIFIED, AnswerErrorCategory.UNRECOGNIZED,
+        AnswerErrorCategory.NO_ERROR -> null
       }
+      currentErrorCategory = if (pendingAnswerError == null) {
+        AnswerErrorCategory.NO_ERROR
+      } else category
       errorMessage.set(pendingAnswerError)
     }
     return pendingAnswerError

--- a/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/SelectionInteractionViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/SelectionInteractionViewModel.kt
@@ -3,6 +3,7 @@ package org.oppia.android.app.player.state.itemviewmodel
 import androidx.databinding.Observable
 import androidx.databinding.ObservableField
 import androidx.databinding.ObservableList
+import org.oppia.android.app.model.AnswerErrorCategory
 import org.oppia.android.app.model.Interaction
 import org.oppia.android.app.model.InteractionObject
 import org.oppia.android.app.model.ItemSelectionRawAnswer
@@ -114,6 +115,7 @@ class SelectionInteractionViewModel private constructor(
     itemSelection = ItemSelectionRawAnswer.newBuilder().apply {
       addAllSelectedIndexes(selectedItems)
     }.build()
+    lastErrorCategory = AnswerErrorCategory.NO_ERROR
   }.build()
 
   /** Returns an HTML list containing all of the HTML string elements as items in the list. */

--- a/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/TextInputViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/TextInputViewModel.kt
@@ -5,6 +5,7 @@ import android.text.TextWatcher
 import androidx.databinding.Observable
 import androidx.databinding.ObservableField
 import org.oppia.android.R
+import org.oppia.android.app.model.AnswerErrorCategory
 import org.oppia.android.app.model.Interaction
 import org.oppia.android.app.model.InteractionObject
 import org.oppia.android.app.model.RawUserAnswer
@@ -28,7 +29,7 @@ class TextInputViewModel private constructor(
   private val resourceHandler: AppLanguageResourceHandler,
   private val translationController: TranslationController
 ) : StateItemViewModel(ViewType.TEXT_INPUT_INTERACTION), InteractionAnswerHandler {
-  var answerText: CharSequence = rawUserAnswer.textualAnswer ?: ""
+  var answerText: CharSequence = rawUserAnswer.textualAnswer
   val hintText: CharSequence = deriveHintText(interaction)
 
   var isAnswerAvailable = ObservableField<Boolean>(false)
@@ -79,6 +80,7 @@ class TextInputViewModel private constructor(
     if (answerText.isNotEmpty()) {
       textualAnswer = answerText.toString()
     }
+    lastErrorCategory = AnswerErrorCategory.NO_ERROR
   }.build()
 
   private fun deriveHintText(interaction: Interaction): CharSequence {

--- a/app/src/main/java/org/oppia/android/app/testing/InputInteractionViewTestActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/testing/InputInteractionViewTestActivity.kt
@@ -11,6 +11,7 @@ import org.oppia.android.app.activity.InjectableAppCompatActivity
 import org.oppia.android.app.customview.interaction.FractionInputInteractionView
 import org.oppia.android.app.customview.interaction.NumericInputInteractionView
 import org.oppia.android.app.customview.interaction.TextInputInteractionView
+import org.oppia.android.app.model.AnswerErrorCategory
 import org.oppia.android.app.model.InputInteractionViewTestActivityParams
 import org.oppia.android.app.model.InputInteractionViewTestActivityParams.MathInteractionType.ALGEBRAIC_EXPRESSION
 import org.oppia.android.app.model.InputInteractionViewTestActivityParams.MathInteractionType.MATH_EQUATION
@@ -22,7 +23,6 @@ import org.oppia.android.app.model.RawUserAnswer
 import org.oppia.android.app.model.SchemaObject
 import org.oppia.android.app.model.UserAnswer
 import org.oppia.android.app.model.WrittenTranslationContext
-import org.oppia.android.app.player.state.answerhandling.AnswerErrorCategory
 import org.oppia.android.app.player.state.answerhandling.InteractionAnswerErrorOrAvailabilityCheckReceiver
 import org.oppia.android.app.player.state.answerhandling.InteractionAnswerReceiver
 import org.oppia.android.app.player.state.itemviewmodel.FractionInteractionViewModel

--- a/app/src/main/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerViewModel.kt
@@ -4,9 +4,9 @@ import androidx.databinding.ObservableBoolean
 import androidx.databinding.ObservableField
 import androidx.databinding.ObservableList
 import org.oppia.android.R
+import org.oppia.android.app.model.AnswerErrorCategory
 import org.oppia.android.app.model.RawUserAnswer
 import org.oppia.android.app.model.UserAnswer
-import org.oppia.android.app.player.state.answerhandling.AnswerErrorCategory
 import org.oppia.android.app.player.state.answerhandling.InteractionAnswerHandler
 import org.oppia.android.app.player.state.itemviewmodel.StateItemViewModel
 import org.oppia.android.app.translation.AppLanguageResourceHandler

--- a/app/src/sharedTest/java/org/oppia/android/app/customview/interaction/MathExpressionInteractionsViewTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/customview/interaction/MathExpressionInteractionsViewTest.kt
@@ -30,6 +30,8 @@ import org.oppia.android.app.application.ApplicationStartupListenerModule
 import org.oppia.android.app.application.testing.TestingBuildFlavorModule
 import org.oppia.android.app.devoptions.DeveloperOptionsModule
 import org.oppia.android.app.devoptions.DeveloperOptionsStarterModule
+import org.oppia.android.app.model.AnswerErrorCategory.REAL_TIME
+import org.oppia.android.app.model.AnswerErrorCategory.SUBMIT_TIME
 import org.oppia.android.app.model.CustomSchemaValue
 import org.oppia.android.app.model.InputInteractionViewTestActivityParams
 import org.oppia.android.app.model.InputInteractionViewTestActivityParams.MathInteractionType
@@ -40,8 +42,6 @@ import org.oppia.android.app.model.SchemaObjectList
 import org.oppia.android.app.model.SubtitledUnicode
 import org.oppia.android.app.model.Translation
 import org.oppia.android.app.model.WrittenTranslationContext
-import org.oppia.android.app.player.state.answerhandling.AnswerErrorCategory.REAL_TIME
-import org.oppia.android.app.player.state.answerhandling.AnswerErrorCategory.SUBMIT_TIME
 import org.oppia.android.app.player.state.itemviewmodel.SplitScreenInteractionModule
 import org.oppia.android.app.shim.ViewBindingShimModule
 import org.oppia.android.app.testing.InputInteractionViewTestActivity

--- a/model/src/main/proto/exploration.proto
+++ b/model/src/main/proto/exploration.proto
@@ -328,18 +328,38 @@ message ItemSelectionRawAnswer {
 }
 
 // Corresponds to a raw representation of the current answer entered by the user which is used to
-// retain state on configuration changes.
+// retain state on configuration changes. Note that this structure is semi-ephemeral in that it will
+// only ever be stored on-disk by Android and never by the app.
 message RawUserAnswer {
+  // Represents the last error state the user's pending answer was in (to help with reconstituting
+  // the answer's state).
+  AnswerErrorCategory last_error_category = 1;
+
   oneof answer_input_type {
     // A raw answer entered by user in a text-based interactions.
-    string textual_answer = 1;
+    string textual_answer = 2;
     // A user's selection for item selection and multiple choice interactions.
-    ItemSelectionRawAnswer item_selection = 2;
+    ItemSelectionRawAnswer item_selection = 3;
     // A user's selection for image region selection interaction.
-    ImageWithRegions.LabeledRegion image_region_selection = 3;
+    ImageWithRegions.LabeledRegion image_region_selection = 4;
     // A user's selected list of set of html content ids in drag and drop interaction.
-    ListOfSetsOfTranslatableHtmlContentIds list_of_sets_of_translatable_html_content_ids = 4;
+    ListOfSetsOfTranslatableHtmlContentIds list_of_sets_of_translatable_html_content_ids = 5;
   }
+}
+
+// Represents categories of errors that can be inferred from a pending answer.
+enum AnswerErrorCategory {
+  // Corresponds to an unknown or unsupported error category.
+  ANSWER_ERROR_CATEGORY_UNSPECIFIED = 0;
+
+  // Corresponds to the pending answer having zero errors.
+  NO_ERROR = 1;
+
+  // Corresponds to errors that may be found while the user is trying to input an answer.
+  REAL_TIME = 2;
+
+  // Corresponds to errors that may be found only when a user tries to submit an answer.
+  SUBMIT_TIME = 3;
 }
 
 message AnswerAndResponse {


### PR DESCRIPTION
Specifically:
- Uses add() again instead of replace() for ExplorationFragment
- Avoids submitting wrong answers (which avoids a hideKeyboard() crash)
- Stores the current answer error (if any) in RawUserAnswer so that it can be restored (required moving AnswerErrorCategory to be a proto enum)
- Generically restores both real-time and submit-time errors

No test changes have been included in this commit.